### PR TITLE
ich bete das es dass war

### DIFF
--- a/order/orderModels.py
+++ b/order/orderModels.py
@@ -11,7 +11,7 @@ from .orderCRUD import StatusEnum
 class Order(SQLModel, table=True):
     unique_order_id: int | None = Field(default=None, primary_key=True)
     
-    user_id: str = Field()  
+    user_id: str | None = Field(default=None,index=True)  
     created_at: date = Field(default_factory=date.today)
     status: StatusEnum = Field()
     

--- a/order/orderServices.py
+++ b/order/orderServices.py
@@ -40,9 +40,8 @@ class OrderItemService():
         self.session = session
         self.orderRepo = OrderItemRepository(session)
         
-    def add_order_items(self, json_list: list[dict]) -> OrderResponse:
-        order_items = self.orderRepo.convert_json_to_order_items(json_list)
-        return self.orderRepo.add_bulk_of_items_to_order(order_items)
+    def add_order_items(self, json_list: list[OrderItemCreate]) -> OrderResponse:
+        return self.orderRepo.add_bulk_of_items_to_order(json_list)
     
     def read_by_unique_order_item_id(self, unique_order_item_id :int) -> OrderItemResponse:
         return self.orderRepo.get_by_id(unique_order_item_id)
@@ -53,5 +52,4 @@ class OrderItemService():
     def delete_an_order_item(self, unique_oder_item_id :int) -> None:
         return self.orderRepo.delete_by_id(unique_oder_item_id)
     
-#TODO: soll alles auf einmal geschickt werden? oder wie jetzt erst bestellung, dann jedes item einzeln
-#TODO: Payment einrichten, stripe? Gute Doku
+

--- a/routers/order.py
+++ b/routers/order.py
@@ -17,7 +17,7 @@ async def add_order(order: OrderCreate, session: Session = Depends(get_session))
 async def get_order_by_order_id(unique_order_id: int, session: Session = Depends(get_session)):
     return OrderService(session).read_by_unique_order_id(unique_order_id)
 
-@order_router.get("/order/{user_id}", response_model=OrderResponse)
+@order_router.get("/order/user/{user_id}", response_model=list[OrderResponse])
 async def get_order_by_user_id(user_id: str, session: Session = Depends(get_session)):
     return OrderService(session).read_by_unique_user_id(user_id)
 
@@ -31,8 +31,8 @@ async def delete_order(unique_order_id: int, session: Session = Depends(get_sess
 
 
 # OrderItem                                                
-@order_router.post("/order/item", response_model=OrderItemResponse)
-async def add_order_item(json_list: list[dict], session: Session = Depends(get_session)):
+@order_router.post("/order/item", response_model=OrderResponse)
+async def add_order_item(json_list: list[OrderItemCreate], session: Session = Depends(get_session)):
     return OrderItemService(session).add_order_items(json_list)                                  
                                                   
 @order_router.get("/order/item/{unique_order_item_id}", response_model=OrderItemResponse)


### PR DESCRIPTION
Größte scheiße die man sich vorstellen kann, gab 2 get endpunkte für order
1. @order_router.get("/order/{unique_order_id}"  --> erwartet int
2. @order_router.get("/order/{user_id}"   -->  erwartet string

Anscheinend reicht die unterscheidung in den variablenname nicht, macht ja auch sinn
Beim Aufruf von     "2. @order_router.get("/order/{user_id}""     hat das aus irgendeinen fickgrund 
manchmal stattdessem heimlich 
"1. @order_router.get("/order/{unique_order_id}""     im backend geroutet ohne dir was zu sagen, 
der einzige fehler war dann expected int can´t be parsed from string oder so nh scheiße

umbennen hats gelöst........ + paar andere sachen wenn ich schon dabei bin